### PR TITLE
修正about页面的换行问题

### DIFF
--- a/content/en/about/_index.html
+++ b/content/en/about/_index.html
@@ -16,7 +16,7 @@ menu:
 
   {{% blocks/lead %}}
   <div class="col-12">
-    <h3 class="text-center">The service mesh technology characterized by Istio is attracting more and more attention from enterprises. It uses sidecars and iptables to intercept traffic with the compromise of performance. Over the past two years, eBPF has become a trending technology, creating many projects based on eBPF.</h3>
+    <h3 class="text-center" style="WORD-BREAK: break-all; WORD-WRAP: break-word">The service mesh technology characterized by Istio is attracting more and more attention from enterprises. It uses sidecars and iptables to intercept traffic with the compromise of performance. Over the past two years, eBPF has become a trending technology, creating many projects based on eBPF.</h3>
   </div>
   {{% /blocks/lead %}}
 
@@ -24,7 +24,7 @@ menu:
   {{< blocks/section>}}
 
     <div class="col-12">
-      <h3 class="text-center">eBPF’s <b>sockops</b> and <b>redir</b>> capabilities enable more efficient processing of data packets. Therefore, it is possible to accelerate meshes with eBPF instead of iptables.</h3>
+      <h3 class="text-center" style="WORD-BREAK: break-all; WORD-WRAP: break-word">eBPF’s <b>sockops</b> and <b>redir</b>> capabilities enable more efficient processing of data packets. Therefore, it is possible to accelerate meshes with eBPF instead of iptables.</h3>
     </div>
 
     {{< /blocks/section>}}
@@ -34,7 +34,7 @@ menu:
     {{< blocks/section >}}
 
     <div class="col-12">
-      <h3 class="text-center">We have created an open source project called Merbridge, which allows you to accelerate your meshes with eBPF by applying just one command in your Istio-managed cluster.</h3>
+      <h3 class="text-center" style="WORD-BREAK: break-all; WORD-WRAP: break-word">We have created an open source project called Merbridge, which allows you to accelerate your meshes with eBPF by applying just one command in your Istio-managed cluster.</h3>
     </div>
 
     {{< /blocks/section >}}

--- a/content/zh/about/_index.html
+++ b/content/zh/about/_index.html
@@ -16,7 +16,7 @@ menu:
  
     {{% blocks/lead %}}
     <div class="col-12">
-      <h3 class="text-center">以 Istio 为首的服务网格技术正在被越来越多的企业所关注，其使用 Sidecar 借助 iptables 技术实现流量拦截，但是使用 iptables 的方式进行拦截会损失不少性能。近两年，由于 eBPF 技术的兴起，不少围绕 eBPF 的项目应声而出。</h3>
+      <h3 class="text-center" style="WORD-BREAK: break-all; WORD-WRAP: break-word">以 Istio 为首的服务网格技术正在被越来越多的企业所关注，其使用 Sidecar 借助 iptables 技术实现流量拦截，但是使用 iptables 的方式进行拦截会损失不少性能。近两年，由于 eBPF 技术的兴起，不少围绕 eBPF 的项目应声而出。</h3>
     </div>
     {{% /blocks/lead %}}
 
@@ -24,7 +24,7 @@ menu:
     {{< blocks/section>}}
 
       <div class="col-12">
-        <h3 class="text-center">借助 eBPF 的 sockops 和 redir 能力，可以高效的处理数据包，再结合实际场景，那么我们就可以使用 eBPF 去代替 iptables 为 Istio 进行加速。</h3>
+        <h3 class="text-center" style="WORD-BREAK: break-all; WORD-WRAP: break-word">借助 eBPF 的 sockops 和 redir 能力，可以高效的处理数据包，再结合实际场景，那么我们就可以使用 eBPF 去代替 iptables 为 Istio 进行加速。</h3>
       </div>
 
       {{< /blocks/section>}}
@@ -32,7 +32,7 @@ menu:
 
       {{< blocks/section >}}
       <div class="col-12">
-        <h3 class="text-center">现在，我们开源了 Merbridge 项目，只需要在您的 Istio 集群执行一条命令，即可直接使用 eBPF 代替 iptables 实现网络加速！</h3>
+        <h3 class="text-center" style="WORD-BREAK: break-all; WORD-WRAP: break-word">现在，我们开源了 Merbridge 项目，只需要在您的 Istio 集群执行一条命令，即可直接使用 eBPF 代替 iptables 实现网络加速！</h3>
       </div>
       
       {{< /blocks/section >}}


### PR DESCRIPTION
目前的about页面有一处文字不能换行，需要通过滑动条浏览全文，其他几处可以换行但不够统一美观。所以自己通过网络加了style语法处理换行问题。
另外：“与Solo.io的直播”这个博文，由于是youtube视频，需要连接vpn才能看。不知道有没有办法可以不用vpn就能直接看？